### PR TITLE
rime not need to use opencc and pypinyin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.raw
+*.source
+*.gz
+zhwiki-*-all-titles-in-ns0
+*.dict.yaml
+*.dict

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=20200520
+VERSION=20200620
 FILENAME=zhwiki-$(VERSION)-all-titles-in-ns0
 
 all: build
@@ -25,10 +25,11 @@ zhwiki.raw: zhwiki.source
 zhwiki.dict: zhwiki.raw
 	libime_pinyindict zhwiki.raw zhwiki.dict
 
-zhwiki.dict.yaml: zhwiki.raw
-	sed 's/[ ][ ]*/\t/g' zhwiki.raw > zhwiki.rime.raw
-	sed -i 's/\t0//g' zhwiki.rime.raw
-	sed -i "s/'/ /g" zhwiki.rime.raw
+zhwiki.rime.raw: zhwiki.source
+	./convert.py zhwiki.source --rime > zhwiki.rime.raw
+
+zhwiki.dict.yaml: zhwiki.rime.raw
+	echo '# zhwiki-$(VERSION)' > zhwiki.dict.yaml
 	echo -e '---\nname: zhwiki\nversion: "0.1"\nsort: by_weight\n...\n' >> zhwiki.dict.yaml
 	cat zhwiki.rime.raw >> zhwiki.dict.yaml
 

--- a/convert.py
+++ b/convert.py
@@ -39,8 +39,8 @@ def is_good_title(title, previous_title=None):
         return False
 
     if previous_title and \
-      len(previous_title) >= 4 and \
-      title.startswith(previous_title):
+            len(previous_title) >= 4 and \
+            title.startswith(previous_title):
         return False
 
     return True
@@ -50,28 +50,41 @@ def log_count(count):
     logging.info(f'{count} words generated')
 
 
-def make_output(word, pinyin):
-    return '\t'.join([word, pinyin, '0'])
-
-
-def main():
+def process(convert_title, title_to_line):
     previous_title = None
     result_count = 0
     with open(sys.argv[1]) as f:
         for line in f:
-            title = _TO_SIMPLIFIED_CHINESE.convert(line.strip())
+            title = convert_title(line.strip())
             if is_good_title(title, previous_title):
-                pinyin = _PINYIN_SEPARATOR.join(lazy_pinyin(title))
-                if pinyin == title:
-                    logging.info(
-                        f'Failed to convert to Pinyin. Ignoring: {pinyin}')
-                    continue
-                print(make_output(title, pinyin))
+                line = title_to_line(title)
+                if line is not None:
+                    print(line)
                 result_count += 1
                 if result_count % _LOG_EVERY == 0:
                     log_count(result_count)
                 previous_title = title
     log_count(result_count)
+
+
+def main():
+    if sys.argv[2] == '--rime':
+        process(
+            convert_title=lambda it: it,
+            title_to_line=lambda it: it
+        )
+    else:
+        def title_to_line(title):
+            pinyin = _PINYIN_SEPARATOR.join(lazy_pinyin(title))
+            if pinyin == title:
+                logging.info(
+                    f'Failed to convert to Pinyin. Ignoring: {pinyin}')
+                return None
+            return '\t'.join([title, pinyin, '0'])
+        process(
+            convert_title=lambda it: _TO_SIMPLIFIED_CHINESE.convert(it),
+            title_to_line=title_to_line
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
rime自带opencc，内置的字典都是繁体字典，故不需要简繁转换
rime自带自动注音功能，并且能够处理多音字，故不需要手动注音，[详见](https://github.com/rime/home/wiki/RimeWithSchemata#%E5%85%AB%E8%82%A1%E6%96%87)

关于rime的多音字处理，例如：`長月達平`，会自动添加`chang yue da ping`和`zhang yue da ping`两个拼音，比pypinyin方便多了😅

关掉pypinyin的注音后，还有个好处，词典文件小一半（
