### PR TITLE
Install to user dir instead of system dir

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ $ rime-install felixonmars/fcitx5-pinyin-zhwiki
 Download latest version of "zhwiki.dict" from:
 https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases
 
-Copy into /usr/share/fcitx5/pinyin/dictionaries/ (create the folder if it does not exist)
+Copy into ~/.local/share/fcitx5/pinyin/dictionaries/ (create the folder if it does not exist)
 
 
 


### PR DESCRIPTION
System dir should be used when install from system packages. For manual installation, user dir is preferred.