### PR TITLE
more portable Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ zhwiki.dict.yaml: zhwiki.raw
 	sed 's/[ ][ ]*/\t/g' zhwiki.raw > zhwiki.rime.raw
 	sed -i 's/\t0//g' zhwiki.rime.raw
 	sed -i "s/'/ /g" zhwiki.rime.raw
-	echo -e '---\nname: zhwiki\nversion: "0.1"\nsort: by_weight\n...\n' > zhwiki.dict.yaml
+	printf -- '---\nname: zhwiki\nversion: "0.1"\nsort: by_weight\n...\n' > zhwiki.dict.yaml
 	cat zhwiki.rime.raw >> zhwiki.dict.yaml
 
 install: zhwiki.dict


### PR DESCRIPTION
`echo -e` sometimes behaves weird in Makefile with extra `-e` output to file (e.g. I find it when building in Github Action), see https://unix.stackexchange.com/questions/700675/why-is-echo-e-behaving-weird-in-a-makefile.