### PR TITLE
feat: Exclude wrong words from dictionary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ ZHDICT_FILENAME=zhwiktionary-$(VERSION)-all-titles-in-ns0
 ZHSRC_FILENAME=zhwikisource-$(VERSION)-all-titles-in-ns0
 WEB_SLANG_FILE=web-slang-$(WEB_SLANG_VERSION).txt
 WEB_SLANG_SOURCE=web-slang-$(WEB_SLANG_VERSION).wikitext
+ZHWIKI_EXCLUDE_TITLES_VERSION=20251010
+ZHWIKI_EXCLUDE_TITLES_FILE=zhwiki-exclude-titles-$(ZHWIKI_EXCLUDE_TITLES_VERSION).txt
 
 .DELETE_ON_ERROR:
 
@@ -31,6 +33,9 @@ $(WEB_SLANG_SOURCE):
 $(WEB_SLANG_FILE): $(WEB_SLANG_SOURCE)
 	./zhwiki-web-slang.py --process $(WEB_SLANG_SOURCE) > $(WEB_SLANG_FILE)
 
+$(ZHWIKI_EXCLUDE_TITLES_FILE):
+	./zhwiki-exclude-titles.py --save $@
+
 %: %.gz
 	gzip -k -d $<
 
@@ -46,8 +51,17 @@ zhwikisource.source: $(ZHSRC_FILENAME)
 web-slang.source: $(WEB_SLANG_FILE)
 	cp $< $@
 
-%.raw: %.source
-	./convert.py $< > $@.tmp
+zhwiki-exclude.txt: $(ZHWIKI_EXCLUDE_TITLES_FILE)
+	cp $< $@
+
+zhwiktionary-exclude.txt:
+	touch $@
+
+zhwikisource-exclude.txt:
+	touch $@
+
+%.raw: %.source %-exclude.txt
+	./convert.py $< $*-exclude.txt > $@.tmp
 	sort -u $@.tmp > $@
 
 %.dict: %.raw
@@ -75,3 +89,4 @@ clean:
 	rm -f $(ZHDICT_FILENAME).gz $(ZHDICT_FILENAME) zhwiktionary.source zhwiktionary.raw zhwiktionary.raw.tmp zhwiktionary.dict zhwiktionary.dict.yaml zhwiktionary.rime.raw
 	rm -f $(ZHSRC_FILENAME).gz $(ZHSRC_FILENAME) zhwikisource.source zhwikisource.raw zhwikisource.raw.tmp zhwikisource.dict zhwikisource.dict.yaml zhwikisource.rime.raw
 	rm -f $(WEB_SLANG_SOURCE) $(WEB_SLANG_FILE) web-slang.source web-slang.raw web-slang.raw.tmp web-slang.dict web-slang.dict.yaml web-slang.rime.raw
+	rm -f ${ZHWIKI_EXCLUDE_TITLES_FILE} zhwiki-exclude-titles-*.txt zhwiki-exclude.txt zhwiktionary-exclude.txt zhwikisource-exclude.txt

--- a/zhwiki-exclude-titles.py
+++ b/zhwiki-exclude-titles.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import collections
+import sys
+from mediawiki import init_session, do_request
+
+
+def fetch():
+    # https://www.mediawiki.org/wiki/API:Categorymembers
+    _API_URL = "https://zh.wikipedia.org/w/api.php"
+    _CATEGORY_TITLE = "Category:錯字重定向"
+
+    init_session()
+    titles = collections.OrderedDict()
+    base_params = {
+        "action": "query",
+        "format": "json",
+        "list": "categorymembers",
+        "cmtitle": _CATEGORY_TITLE,
+        "cmlimit": "max",
+        "cmprop": "title",
+    }
+    continuation = {}
+
+    while True:
+        query_params = {**base_params, **continuation}
+        response = do_request(_API_URL, params=query_params)
+        payload = response.json()
+        members = payload.get("query", {}).get("categorymembers", [])
+        for member in members:
+            titles[member["title"]] = None  # Ordered set behaviour
+
+        continuation = payload.get("continue")
+        if not continuation:
+            break
+
+    return list(titles.keys())
+
+
+def print_titles(titles):
+    for title in titles:
+        print(title)
+
+
+def save_titles(path, titles):
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(title + "\n" for title in titles)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print_titles(fetch())
+
+    elif sys.argv[1] == "--fetch":
+        print_titles(fetch())
+
+    elif sys.argv[1] == "--save":
+        if len(sys.argv) < 3:
+            raise ValueError("Missing path for --save")
+        save_titles(sys.argv[2], fetch())
+
+    else:
+        raise NotImplementedError


### PR DESCRIPTION
Related issue:
- #42 

Some words are misspelled and should not be included in the final dictionary. However, Chinese Wikipedia has a category called "Misspelled Redirects" ([錯字重定向](https://zh.wikipedia.org/wiki/Category:%E9%8C%AF%E5%AD%97%E9%87%8D%E5%AE%9A%E5%90%91)), which lists redirect pages with common misspellings or misattributions in their titles (For example, `知识份子`). I believe these words should be excluded from the final dictionary. Therefore, I added a file `zhwiki-exclude-titles.py` to retrieve all misspelled words and then exclude them in `convert.py` during dictionary generation.

Close #42 