### PR TITLE
pinyin: adjust 炔 pinyin weight from 'guì,quē' to 'quē,guì'

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -9,7 +9,7 @@ import re
 import sys
 
 import opencc
-from pypinyin import lazy_pinyin
+from pypinyin import lazy_pinyin, load_single_dict
 
 # Require at least 2 characters
 _MINIMUM_LEN = 2
@@ -61,6 +61,9 @@ def make_output(word, pinyin):
 def main():
     previous_title = None
     result_count = 0
+    # FIXME: Workaround for https://github.com/mozillazg/pinyin-data/issues/57
+    #        and https://github.com/felixonmars/fcitx5-pinyin-zhwiki/issues/45
+    load_single_dict({ord('炔'): 'quē,guì'}) 
     with open(sys.argv[1]) as f:
         for line in f:
             title = _TO_SIMPLIFIED_CHINESE.convert(line.strip())


### PR DESCRIPTION
Workaround for https://github.com/felixonmars/fcitx5-pinyin-zhwiki/issues/45 and https://github.com/mozillazg/pinyin-data/issues/57