### PR TITLE
Add DELETE_ON_ERROR so Make will remove target file if recipe failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ FILENAME=zhwiki-$(VERSION)-all-titles-in-ns0
 WEB_SLANG_FILE=web-slang-$(WEB_SLANG_VERSION).txt
 WEB_SLANG_SOURCE=web-slang-$(WEB_SLANG_VERSION).source
 
+.DELETE_ON_ERROR:
+
 all: build
 
 build: zhwiki.dict


### PR DESCRIPTION
Especially for targets with output redirect, if the recipe failed, it will leave a middle way target file and Make will think this target finished successfully.

For document, see https://www.gnu.org/software/make/manual/html_node/Special-Targets.html