### PR TITLE
feat: add more list page endings for filtering

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -16,6 +16,9 @@ _MINIMUM_LEN = 2
 _LIST_PAGE_ENDINGS = [
     '列表',
     '对照表',
+    '年表',
+    '得奖名单',
+    '获奖名单',
 ]
 _LOG_EVERY = 1000
 


### PR DESCRIPTION
## Summary

This PR adds `年表`, `得奖名单`, and `获奖名单` to `_LIST_PAGE_ENDINGS` in `convert.py`.

These suffixes are commonly used by list-like Wikipedia page titles rather than normal lexical entries, and filtering them helps reduce noisy entries in the generated dictionary.

## Evidence

Based on scans of the existing dictionary data, a large number of redundant entries follow these patterns:

*   `年表`:
    *   `世界史年表`
    *   `二战年表`
    *   `化学年表`
    *   ...and ~90 similar entries.

*   `得奖名单` / `获奖名单`:
    *   `第一届十大中文金曲得奖名单`
    *   `复仇者联盟获奖名单`
    *   `死侍获奖名单`

<details>
<summary>`年表` - Click to expand</summary>

```text
世界史年表      shi jie shi nian biao
东史年表        dong shi nian biao
中世纪年表      zhong shi ji nian biao
中国制度史年表  zhong guo zhi du shi nian biao
中国计算机科学大事年表  zhong guo ji suan ji ke xue da shi nian biao
二战年表        er zhan nian biao
二战犹太人大屠杀大事年表        er zhan you tai ren da tu sha da shi nian biao
交通技术年表    jiao tong ji shu nian biao
元明清历史年表  yuan ming qing li shi nian biao
六国年表        liu guo nian biao
化学年表        hua xue nian biao
北宋大事年表    bei song da shi nian biao
医学和医学技术年表      yi xue he yi xue ji shu nian biao
医学和医疗技术年表      yi xue he yi liao ji shu nian biao
南宋大事年表    nan song da shi nian biao
南明内阁辅臣年表        nan ming nei ge fu chen nian biao
历代帝王年表    li dai di wang nian biao
反向年表        fan xiang nian biao
发明年表        fa ming nian biao
古兰经年表      gu lan jing nian biao
古埃及年表      gu ai ji nian biao
古埃及王朝年表  gu ai ji wang chao nian biao
古罗马历史年表  gu luo ma li shi nian biao
古罗马年表      gu luo ma nian biao
史前台湾历史年表        shi qian tai wan li shi nian biao
各国首次轨道发射年表    ge guo shou ci gui dao fa she nian biao
周恩来任职年表  zhou en lai ren zhi nian biao
商朝历史年表    shang chao li shi nian biao
圆周率计算年表  yuan zhou lv ji suan nian biao
土耳其历史年表  tu er qi li shi nian biao
埔里地区历史年表        pu li di qu li shi nian biao
夏商周历史年表  xia shang zhou li shi nian biao
夏商周年表      xia shang zhou nian biao
大爆炸年表      da bao zha nian biao
大霹雳年表      da pi li nian biao
天文学大事年表  tian wen xue da shi nian biao
太阳系年表      tai yang xi nian biao
太阳系探索年表  tai yang xi tan suo nian biao
宇宙学年表      yu zhou xue nian biao
宇宙年表        yu zhou nian biao
宇宙形成年表    yu zhou xing cheng nian biao
宋朝农业科技史年表      song chao nong ye ke ji shi nian biao
宗教年表        zong jiao nian biao
对数年表        dui shu nian biao
年表    nian biao
彰化市历史年表  zhang hua shi li shi nian biao
心理学年表      xin li xue nian biao
战后台湾历史年表        zhan hou tai wan li shi nian biao
战国历史年表    zhan guo li shi nian biao
战国年表        zhan guo nian biao
数论年表        shu lun nian biao
文革年表        wen ge nian biao
新年表  xin nian biao
明朝七卿年表    ming chao qi qing nian biao
明朝农业科技史年表      ming chao nong ye ke ji shi nian biao
明朝南京七卿年表        ming chao nan jing qi qing nian biao
明朝南京尚书与都御史年表        ming chao nan jing shang shu yu dou yu shi nian biao
明朝尚书与都御使年表    ming chao shang shu yu dou yu shi nian biao
明朝尚书与都御史年表    ming chao shang shu yu dou yu shi nian biao
明朝阁院大学士年表      ming chao ge yuan da xue shi nian biao
明郑台湾历史年表        ming zheng tai wan li shi nian biao
星图与星表年表  xing tu yu xing biao nian biao
星系年表        xing xi nian biao
春秋历史年表    chun qiu li shi nian biao
晋十六国南北朝历史年表  jin shi liu guo nan bei chao li shi nian biao
望远镜技术年表  wang yuan jing ji shu nian biao
毛泽东大事年表  mao ze dong da shi nian biao
毛泽东年表      mao ze dong nian biao
水沙连地区历史年表      shui sha lian di qu li shi nian biao
汉朝农业科技史年表      han chao nong ye ke ji shi nian biao
火星水探索年表  huo xing shui tan suo nian biao
犹太锡安复国主义运动大事年表    you tai xi an fu guo zhu yi yun dong da shi nian biao
玉环大事年表    yu huan da shi nian biao
瓦剌历史年表    wa la li shi nian biao
生物与有机化学年表      sheng wu yu you ji hua xue nian biao
疾病发现年表    ji bing fa xian nian biao
知名病毒及蠕虫的历史年表        zhi ming bing du ji ru chong de li shi nian biao
科学年表        ke xue nian biao
秦汉三国历史年表        qin han san guo li shi nian biao
粒子发现年表    li zi fa xian nian biao
红楼梦大事年表  hong lou meng da shi nian biao
纳尼亚年表      na ni ya nian biao
航天年表        hang tian nian biao
西周历史年表    xi zhou li shi nian biao
西周王年表      xi zhou wang nian biao
越南现代史年表  yue nan xian dai shi nian biao
运输时期史年表  yun shu shi qi shi nian biao
钟嘉欣事业历程年表      zhong jia xin shi ye li cheng nian biao
阿尔达年表      a er da nian biao
隋唐五代十国历史年表    sui tang wu dai shi guo li shi nian biao
青岛市行政区划年表      qing dao shi xing zheng qu hua nian biao
黑洞物理学年表  hei dong wu li xue nian biao
```

</details>

<details>
<summary>`得奖名单` - Click to expand</summary>

```text
广播九十五周年十大中文金曲得奖名单      guang bo jiu shi wu zhou nian shi da zhong wen jin qu de jiang ming dan
第一届十大中文金曲得奖名单      di yi jie shi da zhong wen jin qu de jiang ming dan
第一届新加坡金曲奖得奖名单      di yi jie xin jia po jin qu jiang de jiang ming dan
第七届十大中文金曲得奖名单      di qi jie shi da zhong wen jin qu de jiang ming dan
第七届新加坡金曲奖得奖名单      di qi jie xin jia po jin qu jiang de jiang ming dan
第三十一届十大中文金曲得奖名单  di san shi yi jie shi da zhong wen jin qu de jiang ming dan
第三十七届十大中文金曲得奖名单  di san shi qi jie shi da zhong wen jin qu de jiang ming dan
第三十三届十大中文金曲得奖名单  di san shi san jie shi da zhong wen jin qu de jiang ming dan
第三十九届十大中文金曲得奖名单  di san shi jiu jie shi da zhong wen jin qu de jiang ming dan
第三十五届十大中文金曲得奖名单  di san shi wu jie shi da zhong wen jin qu de jiang ming dan
第三十八届十大中文金曲得奖名单  di san shi ba jie shi da zhong wen jin qu de jiang ming dan
第三十六届十大中文金曲得奖名单  di san shi liu jie shi da zhong wen jin qu de jiang ming dan
第三十四届十大中文金曲得奖名单  di san shi si jie shi da zhong wen jin qu de jiang ming dan
第三十届十大中文金曲得奖名单    di san shi jie shi da zhong wen jin qu de jiang ming dan
第三届十大中文金曲得奖名单      di san jie shi da zhong wen jin qu de jiang ming dan
第三届新加坡金曲奖得奖名单      di san jie xin jia po jin qu jiang de jiang ming dan
第九届十大中文金曲得奖名单      di jiu jie shi da zhong wen jin qu de jiang ming dan
第二十一届十大中文金曲得奖名单  di er shi yi jie shi da zhong wen jin qu de jiang ming dan
第二十七届十大中文金曲得奖名单  di er shi qi jie shi da zhong wen jin qu de jiang ming dan
第二十三届十大中文金曲得奖名单  di er shi san jie shi da zhong wen jin qu de jiang ming dan
第二十九届十大中文金曲得奖名单  di er shi jiu jie shi da zhong wen jin qu de jiang ming dan
第二十二届十大中文金曲得奖名单  di er shi er jie shi da zhong wen jin qu de jiang ming dan
第二十五届十大中文金曲得奖名单  di er shi wu jie shi da zhong wen jin qu de jiang ming dan
第二十八届十大中文金曲得奖名单  di er shi ba jie shi da zhong wen jin qu de jiang ming dan
第二十六届十大中文金曲得奖名单  di er shi liu jie shi da zhong wen jin qu de jiang ming dan
第二十四届十大中文金曲得奖名单  di er shi si jie shi da zhong wen jin qu de jiang ming dan
第二十届十大中文金曲得奖名单    di er shi jie shi da zhong wen jin qu de jiang ming dan
第二届十大中文金曲得奖名单      di er jie shi da zhong wen jin qu de jiang ming dan
第二届新加坡金曲奖得奖名单      di er jie xin jia po jin qu jiang de jiang ming dan
第五届十大中文金曲得奖名单      di wu jie shi da zhong wen jin qu de jiang ming dan
第五届新加坡金曲奖得奖名单      di wu jie xin jia po jin qu jiang de jiang ming dan
第八届十大中文金曲得奖名单      di ba jie shi da zhong wen jin qu de jiang ming dan
第八届新加坡金曲奖得奖名单      di ba jie xin jia po jin qu jiang de jiang ming dan
第六届十大中文金曲得奖名单      di liu jie shi da zhong wen jin qu de jiang ming dan
第六届新加坡金曲奖得奖名单      di liu jie xin jia po jin qu jiang de jiang ming dan
第十一届十大中文金曲得奖名单    di shi yi jie shi da zhong wen jin qu de jiang ming dan
第十七届十大中文金曲得奖名单    di shi qi jie shi da zhong wen jin qu de jiang ming dan
第十三届十大中文金曲得奖名单    di shi san jie shi da zhong wen jin qu de jiang ming dan
第十九届十大中文金曲得奖名单    di shi jiu jie shi da zhong wen jin qu de jiang ming dan
第十二届十大中文金曲得奖名单    di shi er jie shi da zhong wen jin qu de jiang ming dan
第十五届十大中文金曲得奖名单    di shi wu jie shi da zhong wen jin qu de jiang ming dan
第十八届十大中文金曲得奖名单    di shi ba jie shi da zhong wen jin qu de jiang ming dan
第十六届十大中文金曲得奖名单    di shi liu jie shi da zhong wen jin qu de jiang ming dan
第十四届十大中文金曲得奖名单    di shi si jie shi da zhong wen jin qu de jiang ming dan
第十届十大中文金曲得奖名单      di shi jie shi da zhong wen jin qu de jiang ming dan
第四十一届十大中文金曲得奖名单  di si shi yi jie shi da zhong wen jin qu de jiang ming dan
第四十三届十大中文金曲得奖名单  di si shi san jie shi da zhong wen jin qu de jiang ming dan
第四十二届十大中文金曲得奖名单  di si shi er jie shi da zhong wen jin qu de jiang ming dan
第四十五届十大中文金曲得奖名单  di si shi wu jie shi da zhong wen jin qu de jiang ming dan
第四十六届十大中文金曲得奖名单  di si shi liu jie shi da zhong wen jin qu de jiang ming dan
第四十四届十大中文金曲得奖名单  di si shi si jie shi da zhong wen jin qu de jiang ming dan
第四十届十大中文金曲得奖名单    di si shi jie shi da zhong wen jin qu de jiang ming dan
第四届十大中文金曲得奖名单      di si jie shi da zhong wen jin qu de jiang ming dan
第四届新加坡金曲奖得奖名单      di si jie xin jia po jin qu jiang de jiang ming dan
```

</details>

<details>
<summary>`获奖名单` - Click to expand</summary>

```text
复仇者联盟获奖名单      fu chou zhe lian meng huo jiang ming dan
她获奖名单      ta huo jiang ming dan
年轻的维多利亚获奖名单  nian qing de wei duo li ya huo jiang ming dan
死侍获奖名单    si shi huo jiang ming dan
```

</details>